### PR TITLE
PUT request handling

### DIFF
--- a/pkg/cmd/contrail/apisrv.go
+++ b/pkg/cmd/contrail/apisrv.go
@@ -21,7 +21,7 @@ var apiServerCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		server, err := apisrv.NewServer()
 		server.Init()
-                if err != nil {
+		if err != nil {
 			log.Fatal(err)
 		}
 		server.Init()
@@ -31,4 +31,3 @@ var apiServerCmd = &cobra.Command{
 		}
 	},
 }
-

--- a/tools/templates/api.tmpl
+++ b/tools/templates/api.tmpl
@@ -9,8 +9,7 @@ import (
     "github.com/labstack/echo"
     "github.com/Juniper/contrail/pkg/common"
 
-    log "github.com/sirupsen/logrus"
-
+	log "github.com/sirupsen/logrus"
 )
 
 //{{ schema.JSONSchema.GoName }}RESTAPI
@@ -172,4 +171,3 @@ func (api *{{ schema.JSONSchema.GoName }}RESTAPI) List(c echo.Context) (error) {
         "{{ schema.PluralPath }}": result,
     })
 }
-

--- a/tools/templates/db.tmpl
+++ b/tools/templates/db.tmpl
@@ -52,12 +52,12 @@ const delete{{ schema.JSONSchema.GoName }}{{ reference.GoName }}Query = "delete 
 
 // Create{{ schema.JSONSchema.GoName }} inserts {{ schema.JSONSchema.GoName }} to DB
 func Create{{ schema.JSONSchema.GoName }}(tx *sql.Tx, model *models.{{ schema.JSONSchema.GoName }}) error {
-    // Prepare statement for inserting data
-    stmt, err := tx.Prepare(insert{{ schema.JSONSchema.GoName }}Query)
-    if err != nil {
+	// Prepare statement for inserting data
+	stmt, err := tx.Prepare(insert{{ schema.JSONSchema.GoName }}Query)
+	if err != nil {
         return errors.Wrap(err, "preparing create statement failed")
-    }
-    defer stmt.Close()
+	}
+	defer stmt.Close()
     log.WithFields(log.Fields{
         "model": model,
         "query": insert{{ schema.JSONSchema.GoName }}Query,
@@ -328,4 +328,3 @@ func Delete{{ schema.JSONSchema.GoName }}(tx *sql.Tx, uuid string, auth *common.
     }).Debug("deleted")
     return nil
 }
-

--- a/tools/templates/db_test.tmpl
+++ b/tools/templates/db_test.tmpl
@@ -70,4 +70,3 @@ func Test{{ schema.JSONSchema.GoName }}(t *testing.T) {
     }
     return
 }
-

--- a/tools/templates/db_test_main.tmpl
+++ b/tools/templates/db_test_main.tmpl
@@ -26,4 +26,3 @@ func TestMain(m *testing.M) {
     log.Info("finished test")
     os.Exit(code)
 }
-


### PR DESCRIPTION
PUT has been implemented with assumption that it will replace the existing Resource entirely.
Following are changes to handle PUT(update) request.

·         API template changes:

o    createRequest Struct is made generic to hold request body for PUT also.
o    Update handler has been implemented. UUID will be retrieved from params (/PUT/:id). PUT Response will have UUID and URI of resource.

·         DB template changes:

o    update method has been implemented which executes db update. All the old references are deleted from the ref table. New references are added based on the ref UUID from the request body.

Other than this, there are some import changes in template files( imports were missing/ unused imports were present).
