### PR TITLE
updated default static and proxy route

### DIFF
--- a/packaging/apisrv.yml
+++ b/packaging/apisrv.yml
@@ -25,11 +25,13 @@ tls:
 # key: URL path
 # value: file path. (absolute path recommended in production)
 static_files:
-    public: /usr/share/contrail/public
+    /: /usr/share/contrail/public
 
 # API Proxy configuraion
 # key: URL path
 # value: String list of backend host
 proxy:
-    /contrail:
+    /config:
     - http://localhost:8082
+    /telemetry:
+    - http://localhost:8081


### PR DESCRIPTION
- instead of using '/public' in the default static route lets just use '/'
  when we publish the built webui packages app can be directly accessed at http://localhost:9091/

- updated proxy routes for contrail endpoints
    - '/config' to point to api server endpoint :8082
    - '/telemetry' to point to opserver endpoint :8081