### PR TITLE
Fixed the agent sync to process list response

### DIFF
--- a/pkg/agent/task.go
+++ b/pkg/agent/task.go
@@ -68,9 +68,17 @@ func (task *task) init(agent *Agent) {
 }
 
 func (task *task) action(action string, resource map[string]interface{}) error {
+	config := map[string]string{
+		"id":         task.agent.config.ID,
+		"password":   task.agent.config.Password,
+		"project_id": task.agent.config.ProjectID,
+		"auth_url":   task.agent.config.AuthURL,
+		"endpoint":   task.agent.config.Endpoint,
+	}
 	context := pongo2.Context{
 		"resource": resource,
 		"action":   action,
+		"config":   config,
 	}
 	err := task.runHandlers(task.Common, context)
 	if err != nil {

--- a/pkg/agent/task_handler.go
+++ b/pkg/agent/task_handler.go
@@ -113,7 +113,7 @@ func saveHandler(handler handler, task *task, context map[string]interface{}) (i
 	resourceMap, _ := resource.(map[string]interface{})
 	outputData := map[string]interface{}{
 		resourceMap["schema_id"].(string): map[string]interface{}{
-			resourceMap["id"].(string): resourceMap,
+			resourceMap["uuid"].(string): resourceMap,
 		},
 	}
 	if format == "json" {


### PR DESCRIPTION
appropriately

- Fixed agent sync to update schema_id in the
  resource during every poll, before comparing
  it with the existing resource.

- Enhanced the templatehandler to be able to access
  the config data, by adding it in context.

Closes: https://github.com/Juniper/contrail/issues/90